### PR TITLE
fix(cli): exit cli if minimum required node version not met

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,15 @@
 #!/usr/bin/env node
 
+const userNodeVersion = process.versions.node;
+const userNodeMajorVersion = parseInt(userNodeVersion.split('.')[0], 10);
+const minimumMajorVersion = 18;
+
+if (userNodeMajorVersion < minimumMajorVersion) {
+  console.error(`\nError: Your Node.js version is ${userNodeVersion}`);
+  console.error(`Please use Node.js v${minimumMajorVersion} or higher.\n`);
+  process.exit(1);
+}
+
 import { input, select } from '@inquirer/prompts';
 import { blue, green } from 'chalk';
 import { mind } from 'gradient-string';


### PR DESCRIPTION
* Minimum required Node.js version for the CLI is `18`
* This must be strictly enforced because the CLI uses native `fetch` which is only available in Node `>=18`
* Native `fetch` is more lightweight than external request libraries